### PR TITLE
Add null value support in JSON validation

### DIFF
--- a/type.go
+++ b/type.go
@@ -1,6 +1,7 @@
 package govalidator
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -10,8 +11,13 @@ type Int struct {
 	IsSet bool `json:"isSet"`
 }
 
+var null = []byte("null")
+
 // UnmarshalJSON ...
 func (i *Int) UnmarshalJSON(data []byte) error {
+	if bytes.Compare(data, null) == 0 {
+		return nil
+	}
 	i.IsSet = true
 	var temp int
 	if err := json.Unmarshal(data, &temp); err != nil {
@@ -34,6 +40,9 @@ type Int64 struct {
 
 // UnmarshalJSON ...
 func (i *Int64) UnmarshalJSON(data []byte) error {
+	if bytes.Compare(data, null) == 0 {
+		return nil
+	}
 	i.IsSet = true
 	var temp int64
 	if err := json.Unmarshal(data, &temp); err != nil {
@@ -56,6 +65,9 @@ type Float32 struct {
 
 // UnmarshalJSON ...
 func (i *Float32) UnmarshalJSON(data []byte) error {
+	if bytes.Compare(data, null) == 0 {
+		return nil
+	}
 	i.IsSet = true
 	var temp float32
 	if err := json.Unmarshal(data, &temp); err != nil {
@@ -78,6 +90,9 @@ type Float64 struct {
 
 // UnmarshalJSON ...
 func (i *Float64) UnmarshalJSON(data []byte) error {
+	if bytes.Compare(data, null) == 0 {
+		return nil
+	}
 	i.IsSet = true
 	var temp float64
 	if err := json.Unmarshal(data, &temp); err != nil {
@@ -100,6 +115,9 @@ type Bool struct {
 
 // UnmarshalJSON ...
 func (i *Bool) UnmarshalJSON(data []byte) error {
+	if bytes.Compare(data, null) == 0 {
+		return nil
+	}
 	i.IsSet = true
 	var temp bool
 	if err := json.Unmarshal(data, &temp); err != nil {

--- a/validator_test.go
+++ b/validator_test.go
@@ -129,6 +129,46 @@ func TestValidator_ValidateJSON(t *testing.T) {
 	}
 }
 
+func TestValidator_ValidateJSON_NULLValue(t *testing.T) {
+	type User struct {
+		Name   string `json:"name"`
+		Count  Int    `json:"count"`
+		Option Int    `json:"option"`
+		Active Bool   `json:"active"`
+	}
+
+	rules := MapData{
+		"name":   []string{"required"},
+		"count":  []string{"required"},
+		"option": []string{"required"},
+		"active": []string{"required"},
+	}
+
+	postUser := map[string]interface{}{
+		"name":   "John Doe",
+		"count":  0,
+		"option": nil,
+		"active": nil,
+	}
+
+	var user User
+	body, _ := json.Marshal(postUser)
+	req, _ := http.NewRequest("POST", "http://www.example.com", bytes.NewReader(body))
+
+	opts := Options{
+		Request: req,
+		Data:    &user,
+		Rules:   rules,
+	}
+
+	vd := New(opts)
+	vd.SetTagIdentifier("json")
+	validationErr := vd.ValidateJSON()
+	if len(validationErr) != 2 {
+		t.Error("ValidateJSON failed")
+	}
+}
+
 func TestValidator_ValidateJSON_panic(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {


### PR DESCRIPTION
Hi, @thedevsaddam .

Thank you for the great library!
Currently, `govalidator.Int` cannot seems to be handle correctly null value in JSON.
I expect that JSON `null` value should be assigned as `false` value for `IsSet` field.