### PR TITLE
Prevent panic caused by null value in JSON

### DIFF
--- a/roller.go
+++ b/roller.go
@@ -183,6 +183,10 @@ func (r *roller) traverseMap(iface interface{}) {
 	switch t := iface.(type) {
 	case map[string]interface{}:
 		for k, v := range t {
+			// drop null values in json to prevent panic caused by reflect.TypeOf(nil)
+			if v == nil {
+				continue
+			}
 			switch reflect.TypeOf(v).Kind() {
 			case reflect.Struct:
 				r.typeName = k // set the map key as name

--- a/roller_test.go
+++ b/roller_test.go
@@ -83,6 +83,7 @@ func init() {
 	m["person"] = "John Doe"
 	m["iface"] = map[string]string{"another_person": "does it change root!"}
 	m["array"] = [5]int{1, 4, 5, 6, 7}
+	m["null"] = nil
 }
 
 func TestRoller_push(t *testing.T) {


### PR DESCRIPTION
If the request body is a JSON like `{"test":null}`, govalidator will panic when executing `traverseMap`.

```go
var m = make(map[string]interface{})
json.Unmarshal([]byte(`{"test":null}`), &m)
```

Since `m["test"]` is `nil`, `reflect.TypeOf(v)` will panic. This PR fixes the bug by dropping null values in json.