### PR TITLE
Enhancement `numeric_between` to accept unbounded min/max

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Send request to the server using curl or postman: `curl GET "http://localhost:90
 * `between:numeric,numeric` The field under validation check the length of characters/ length of array, slice, map/ range between two integer or float number etc.
 * `numeric` The field under validation must be entirely numeric characters.
 * `numeric_between:numeric,numeric` The field under validation must be a numeric value between the range.
-   e.g: `numeric_between:18,65` may contains numeric value like `35`, `55` . You can also pass float value to check
+   e.g: `numeric_between:18,65` may contains numeric value like `35`, `55` . You can also pass float value to check. Moreover, both bounds can be omitted to create an unbounded minimum (e.g: `numeric_between:,65`) or an unbounded maximum (e.g: `numeric_between:-1,`).
 * `bool` The field under validation must be able to be cast as a boolean. Accepted input are `true, false, 1, 0, "1" and "0"`.
 * `credit_card` The field under validation must have a valid credit card number. Accepted cards are `Visa, MasterCard, American Express, Diners Club, Discover and JCB card`
 * `coordinate` The field under validation must have a value of valid coordinate.

--- a/rules.go
+++ b/rules.go
@@ -3,6 +3,7 @@ package govalidator
 import (
 	"errors"
 	"fmt"
+	"math"
 	"mime/multipart"
 	"net/url"
 	"reflect"
@@ -866,22 +867,31 @@ func init() {
 
 	// NumericBetween check if the value field numeric value range
 	// e.g: numeric_between:18, 65 means number value must be in between a numeric value 18 & 65
+	// Both of the bounds can be omited turning it into a min only (`10,`) or a max only (`,10`)
 	AddCustomRule("numeric_between", func(field string, rule string, message string, value interface{}) error {
 		rng := strings.Split(strings.TrimPrefix(rule, "numeric_between:"), ",")
 		if len(rng) != 2 {
 			panic(errInvalidArgument)
 		}
 		// check for integer value
-		_min, err := strconv.ParseFloat(rng[0], 64)
-		if err != nil {
-			panic(errStringToInt)
+		min := math.MinInt64
+		if rng[0] != "" {
+			_min, err := strconv.ParseFloat(rng[0], 64)
+			if err != nil {
+				panic(errStringToInt)
+			}
+			min = int(_min)
 		}
-		min := int(_min)
-		_max, err := strconv.ParseFloat(rng[1], 64)
-		if err != nil {
-			panic(errStringToInt)
+
+		max := math.MaxInt64
+		if rng[1] != "" {
+			_max, err := strconv.ParseFloat(rng[1], 64)
+			if err != nil {
+				panic(errStringToInt)
+			}
+			max = int(_max)
 		}
-		max := int(_max)
+
 		errMsg := fmt.Errorf("The %s field must be numeric value between %d and %d", field, min, max)
 		if message != "" {
 			errMsg = errors.New(message)
@@ -899,14 +909,23 @@ func init() {
 			}
 		}
 		// check for float value
-		minFloat, err := strconv.ParseFloat(rng[0], 64)
-		if err != nil {
-			panic(errStringToFloat)
+		var err error
+		minFloat := -math.MaxFloat64
+		if rng[0] != "" {
+			minFloat, err = strconv.ParseFloat(rng[0], 64)
+			if err != nil {
+				panic(errStringToFloat)
+			}
 		}
-		maxFloat, err := strconv.ParseFloat(rng[1], 64)
-		if err != nil {
-			panic(errStringToFloat)
+
+		maxFloat := math.MaxFloat64
+		if rng[1] != "" {
+			maxFloat, err = strconv.ParseFloat(rng[1], 64)
+			if err != nil {
+				panic(errStringToFloat)
+			}
 		}
+
 		errMsg = fmt.Errorf("The %s field must be numeric value between %f and %f", field, minFloat, maxFloat)
 		if message != "" {
 			errMsg = errors.New(message)

--- a/rules_test.go
+++ b/rules_test.go
@@ -1409,23 +1409,27 @@ func Test_Numeric_valid(t *testing.T) {
 
 func Test_NumericBetween(t *testing.T) {
 	type user struct {
-		Age   int    `json:"age"`
-		CGPA  string `json:"cgpa"`
-		NAge  int    `json:"nage"`
-		NCGPA string `json:"ncgpa"`
+		Age    int    `json:"age"`
+		CGPA   string `json:"cgpa"`
+		NAge   int    `json:"nage"`
+		NCGPA  string `json:"ncgpa"`
+		Height int    `json:"height"`
+		Weight string `json:"weight"`
 	}
 
-	postUser := user{Age: 77, CGPA: "2.90", NAge: -55, NCGPA: "-2.90"}
+	postUser := user{Age: 77, CGPA: "2.90", NAge: -55, NCGPA: "-2.90", Height: 5, Weight: "-200.0"}
 	var userObj user
 
 	body, _ := json.Marshal(postUser)
 	req, _ := http.NewRequest("POST", "http://www.example.com", bytes.NewReader(body))
 
 	rules := MapData{
-		"age":   []string{"numeric_between:18,60"},
-		"cgpa":  []string{"numeric_between:3.5,4.9"},
-		"nage":  []string{"numeric_between:-60,-18"},
-		"ncgpa": []string{"numeric_between:-4.9,-3.5"},
+		"age":    []string{"numeric_between:18,60"},
+		"cgpa":   []string{"numeric_between:3.5,4.9"},
+		"nage":   []string{"numeric_between:-60,-18"},
+		"ncgpa":  []string{"numeric_between:-4.9,-3.5"},
+		"height": []string{"numeric_between:6,"},
+		"weight": []string{"numeric_between:,-2000.0"},
 	}
 
 	messages := MapData{
@@ -1445,7 +1449,7 @@ func Test_NumericBetween(t *testing.T) {
 	vd := New(opts)
 	validationErr := vd.ValidateJSON()
 
-	if len(validationErr) != 3 {
+	if len(validationErr) != 5 {
 		t.Error("numeric_between validation failed!")
 	}
 


### PR DESCRIPTION
The `numeric_between` is now able to be configured without a min value (`numeric_between:,10`) creating a validator that will accept any values lower or equal to 10 and without a max value (`numeric_between:10,`) creating a validator that will accept any values higher or equal to 10.