### PR TITLE
Added more tests around tag identifier

### DIFF
--- a/roller.go
+++ b/roller.go
@@ -103,14 +103,15 @@ func (r *roller) traverseStruct(iface interface{}) {
 		switch v.Kind() {
 		case reflect.Struct:
 			var typeName string
-			if len(rfv.Tag.Get(r.tagIdentifier)) > 0 {
-				tags := strings.Split(rfv.Tag.Get(r.tagIdentifier), r.tagSeparator)
+			if tag := rfv.Tag.Get(r.tagIdentifier); len(tag) > 0 {
+				tags := strings.Split(tag, r.tagSeparator)
 				if tags[0] != "-" {
 					typeName = tags[0]
 				}
 			} else {
 				typeName = rfv.Name
 			}
+
 			if v.CanInterface() {
 				switch v.Type().String() {
 				case "govalidator.Int":
@@ -148,8 +149,8 @@ func (r *roller) traverseStruct(iface interface{}) {
 				}
 			}
 		default:
-			if len(rfv.Tag.Get(r.tagIdentifier)) > 0 {
-				tags := strings.Split(rfv.Tag.Get(r.tagIdentifier), r.tagSeparator)
+			if tag := rfv.Tag.Get(r.tagIdentifier); len(tag) > 0 {
+				tags := strings.Split(tag, r.tagSeparator)
 				// add if first tag is not hyphen
 				if tags[0] != "-" {
 					if v.CanInterface() {

--- a/validator_test.go
+++ b/validator_test.go
@@ -126,7 +126,7 @@ func TestValidator_ValidateJSON(t *testing.T) {
 	vd.SetTagIdentifier("json")
 	validationErr := vd.ValidateJSON()
 	if len(validationErr) != 5 {
-		t.Error("ValidateJSON failed")
+		t.Errorf("ValidateJSON failed: %v", validationErr)
 	}
 }
 
@@ -166,7 +166,7 @@ func TestValidator_ValidateJSON_NULLValue(t *testing.T) {
 	vd.SetTagIdentifier("json")
 	validationErr := vd.ValidateJSON()
 	if len(validationErr) != 2 {
-		t.Error("ValidateJSON failed")
+		t.Errorf("ValidateJSON failed: %v", validationErr)
 	}
 }
 
@@ -207,7 +207,58 @@ func TestValidator_ValidateStruct(t *testing.T) {
 	vd.SetTagIdentifier("json")
 	validationErr := vd.ValidateStruct()
 	if len(validationErr) != 5 {
-		t.Error("ValidateStruct failed")
+		t.Errorf("ValidateStruct failed: %v", validationErr)
+	}
+}
+
+func TestValidator_ValidateStruct_CustomTagIdentifier(t *testing.T) {
+	type User struct {
+		Random string `schema:"name"`
+	}
+
+	postUser := User{
+		Random: "",
+	}
+
+	rules := MapData{
+		"name": []string{"required"},
+	}
+
+	opts := Options{
+		Data:          &postUser,
+		Rules:         rules,
+		TagIdentifier: "schema",
+	}
+
+	vd := New(opts)
+	validationErr := vd.ValidateStruct()
+	if len(validationErr) != 1 {
+		t.Errorf("ValidateStruct failed: %v", validationErr)
+	}
+}
+
+func TestValidator_ValidateStruct_NoTag(t *testing.T) {
+	type User struct {
+		Random string
+	}
+
+	postUser := User{
+		Random: "",
+	}
+
+	rules := MapData{
+		"Random": []string{"required"},
+	}
+
+	opts := Options{
+		Data:  &postUser,
+		Rules: rules,
+	}
+
+	vd := New(opts)
+	validationErr := vd.ValidateStruct()
+	if len(validationErr) != 0 {
+		t.Errorf("ValidateStruct failed: %v", validationErr)
 	}
 }
 


### PR DESCRIPTION
Small optimization improvements by not calling `rfv.Tag.Get(r.tagIdentifier)` twice in the roller.