### PR TITLE
added default case to traverseStruct for when field is a pointer

### DIFF
--- a/roller.go
+++ b/roller.go
@@ -145,6 +145,26 @@ func (r *roller) traverseStruct(iface interface{}) {
 					if v.CanInterface() {
 						r.traverseMap(v.Interface())
 					}
+				default:
+					if len(rfv.Tag.Get(r.tagIdentifier)) > 0 {
+						tags := strings.Split(rfv.Tag.Get(r.tagIdentifier), r.tagSeparator)
+						// add if first tag is not hyphen
+						if tags[0] != "-" {
+							if v.CanInterface() {
+								r.push(tags[0], v.Interface())
+							}
+						}
+					} else {
+						if v.Kind() == reflect.Ptr {
+							if ifv.CanInterface() {
+								r.push(ift.Name()+"."+rfv.Name, ifv.Interface())
+							}
+						} else {
+							if v.CanInterface() {
+								r.push(ift.Name()+"."+rfv.Name, v.Interface())
+							}
+						}
+					}
 				}
 			}
 		default:

--- a/roller_test.go
+++ b/roller_test.go
@@ -411,3 +411,31 @@ func TestRoller_StartCustomType(t *testing.T) {
 		t.Error("failed to push custom type")
 	}
 }
+
+type structWithPointers struct {
+	Name        *string `json:"name"`
+	Integer     *int    `json:"integer"`
+	AnotherName string  `json:"another_name"`
+	Boolean     *bool   `json:"boolean"`
+}
+
+func TestRoller_StartPointerType(t *testing.T) {
+	r := roller{}
+	testStr := "John Doe"
+	testBool := true
+	data := structWithPointers{
+		Name:        &testStr,
+		Integer:     new(int),
+		AnotherName: "John Doe2",
+		Boolean:     &testBool,
+	}
+
+	r.setTagIdentifier("json")
+	r.setTagSeparator("|")
+	r.start(&data)
+
+	v := r.getFlatMap()
+	if len(v) != 4 {
+		t.Error("failed to push pointer types")
+	}
+}


### PR DESCRIPTION
This fixes an issue preventing pointer from being pushed in roller. 