### PR TITLE
Mime type correction

### DIFF
--- a/doc/FILE_VALIDATION.md
+++ b/doc/FILE_VALIDATION.md
@@ -16,7 +16,7 @@ import (
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	rules := govalidator.MapData{
-		"file:photo": []string{"ext:jpg,png", "size:10000", "mime:jpg,png", "required"},
+		"file:photo": []string{"ext:jpg,png", "size:10000", "mime:image/jpg,image/png", "required"},
 	}
 
 	messages := govalidator.MapData{


### PR DESCRIPTION
Govalidator throws an error

```error
The content field file mime type/subtype is invalid
```
if we do not provide **type** of the mime followed by **/** in MapData